### PR TITLE
Bugfix for `AttributeError: module 'cooler.ice' has no attribute 'Cooler'`

### DIFF
--- a/neoloop/cnv/correctcnv.py
+++ b/neoloop/cnv/correctcnv.py
@@ -4,7 +4,7 @@
 
 import logging, warnings, h5py
 import numpy as np
-from cooler import ice, util
+from cooler import ice, util, Cooler
 from collections import defaultdict
 
 # override the original functions
@@ -172,7 +172,7 @@ def matrix_balance(cool_uri, nproc=1, chunksize=int(1e7), mad_max=5,
         if 'sweight' in grp['bins']:
             del grp['bins']['sweight']
     
-    clr = ice.Cooler(cool_uri)
+    clr = Cooler(cool_uri)
     
     try:
         if nproc > 1:

--- a/neoloop/cnv/correctcnv.py
+++ b/neoloop/cnv/correctcnv.py
@@ -4,7 +4,7 @@
 
 import logging, warnings, h5py
 import numpy as np
-from cooler import ice, util, Cooler
+from cooler import balance, util, Cooler
 from collections import defaultdict
 
 # override the original functions
@@ -18,12 +18,12 @@ def _balance_genomewide(bias, cnv, ucnv, clr, spans, filters, map, tol, max_iter
 
     for _ in range(max_iters):
         marg = (
-            ice.split(clr, spans=spans, map=map, use_lock=use_lock)
-                .prepare(ice._init)
+            balance.split(clr, spans=spans, map=map, use_lock=use_lock)
+                .prepare(balance._init)
                 .pipe(filters)
-                .pipe(ice._timesouterproduct, bias)
-                .pipe(ice._marginalize)
-                .reduce(ice.add, np.zeros(n_bins))
+                .pipe(balance._timesouterproduct, bias)
+                .pipe(balance._marginalize)
+                .reduce(balance.add, np.zeros(n_bins))
         )
         
         nzmarg = marg[marg != 0]
@@ -56,7 +56,7 @@ def _balance_genomewide(bias, cnv, ucnv, clr, spans, filters, map, tol, max_iter
     else:
         warnings.warn(
             'Iteration limit reached without convergence.',
-            ice.ConvergenceWarning)
+            balance.ConvergenceWarning)
     
     bias[bias==0] = np.nan
     for uc in ucnv:
@@ -96,7 +96,7 @@ def iterative_correction(clr, chunksize=int(1e7), map=map, tol=1e-5, min_nnz=10,
     # List of pre-marginalization data transformations
     base_filters = []
     if ignore_diags:
-        base_filters.append(ice.partial(ice._zero_diags, ignore_diags))
+        base_filters.append(balance.partial(balance._zero_diags, ignore_diags))
 
     # Initialize the bias weights
     n_bins = clr.info['nbins']
@@ -104,23 +104,23 @@ def iterative_correction(clr, chunksize=int(1e7), map=map, tol=1e-5, min_nnz=10,
 
     # Drop bins with too few nonzeros from bias
     if min_nnz > 0:
-        filters = [ice._binarize] + base_filters
+        filters = [balance._binarize] + base_filters
         marg_nnz = (
-            ice.split(clr, spans=spans, map=map, use_lock=use_lock)
-                .prepare(ice._init)
+            balance.split(clr, spans=spans, map=map, use_lock=use_lock)
+                .prepare(balance._init)
                 .pipe(filters)
-                .pipe(ice._marginalize)
-                .reduce(ice.add, np.zeros(n_bins))
+                .pipe(balance._marginalize)
+                .reduce(balance.add, np.zeros(n_bins))
         )
         bias[marg_nnz < min_nnz] = 0
 
     filters = base_filters
     marg = (
-        ice.split(clr, spans=spans, map=map, use_lock=use_lock)
-            .prepare(ice._init)
+        balance.split(clr, spans=spans, map=map, use_lock=use_lock)
+            .prepare(balance._init)
             .pipe(filters)
-            .pipe(ice._marginalize)
-            .reduce(ice.add, np.zeros(n_bins))
+            .pipe(balance._marginalize)
+            .reduce(balance.add, np.zeros(n_bins))
     )
 
     # Drop bins with too few total counts from bias
@@ -135,7 +135,7 @@ def iterative_correction(clr, chunksize=int(1e7), map=map, tol=1e-5, min_nnz=10,
             marg[lo:hi] /= np.median(c_marg[c_marg > 0])
         logNzMarg = np.log(marg[marg>0])
         med_logNzMarg = np.median(logNzMarg)
-        dev_logNzMarg = ice.mad(logNzMarg)
+        dev_logNzMarg = balance.mad(logNzMarg)
         cutoff = np.exp(med_logNzMarg - mad_max * dev_logNzMarg)
         bias[marg < cutoff] = 0
     
@@ -176,7 +176,7 @@ def matrix_balance(cool_uri, nproc=1, chunksize=int(1e7), mad_max=5,
     
     try:
         if nproc > 1:
-            pool = ice.Pool(nproc)
+            pool = balance.Pool(nproc)
             map_ = pool.imap_unordered
         else:
             map_ = map

--- a/neoloop/cnv/runcnv.py
+++ b/neoloop/cnv/runcnv.py
@@ -3,7 +3,7 @@
 #cython: cdivision=True
 
 import os, cooler, pyBigWig
-from cooler import ice
+from cooler import balance
 import numpy as np
 import pandas as pd
 from collections import Counter
@@ -13,7 +13,7 @@ def get_marginals(uri, exclude=['M', 'Y', 'MT'], chunksize=int(1e7), nproc=1):
     clr = cooler.Cooler(uri)
 
     if nproc > 1:
-        pool = ice.Pool(nproc)
+        pool = balance.Pool(nproc)
         map_ = pool.imap_unordered
     else:
         map_ = map
@@ -24,11 +24,11 @@ def get_marginals(uri, exclude=['M', 'Y', 'MT'], chunksize=int(1e7), nproc=1):
     spans = list(zip(edges[:-1], edges[1:]))
 
     marg = (
-        ice.split(clr, spans=spans, map=map_, use_lock=False)
-            .prepare(ice._init)
+        balance.split(clr, spans=spans, map=map_, use_lock=False)
+            .prepare(balance._init)
             .pipe([])
-            .pipe(ice._marginalize)
-            .reduce(ice.add, np.zeros(n_bins))
+            .pipe(balance._marginalize)
+            .reduce(balance.add, np.zeros(n_bins))
     )
     table = clr.bins()[:][['chrom', 'start', 'end']]
     table['Coverage'] = marg.astype(int)


### PR DESCRIPTION
Hi again,

I not trying to pepper you with issues or more work, but I think this tool is going to be very useful and want it to work well for people, including myself.
I'm trying to help by identifying bugs and fixing them if I can.

## Reproducing the problem

After using `calculate-cnv` to identify CNVs genome-wide, I'm trying to correct them in the cooler files with `correct-cnv`.
If I run this:

```shell
correct-cnv -f -H /path/to/hic/sample.cool --cnv-file /path/to/output/sample.cnv-calls.bedGraph --logFile /path/to/output/sample.correct-cnv.log
```

I get the following error:

```
root                      INFO    @ 07/27/21 16:37:10:
# ARGUMENT LIST:
# Cooler URI = /path/to/hic/sample.cool
# CNV Profile = /path/to/output/sample.cnv-calls.bedGraph
# Number of Processes = 1
# Log file name = /path/to/output/sample.correct-cnv.log
root                      INFO    @ 07/27/21 16:37:12: Match CNV segmentation to matrix bins
root                      INFO    @ 07/27/21 16:37:14: Perform CNV-separate matrix balancing ...
Traceback (most recent call last):
  File "/mnt/work1/users/home2/hawleyj/miniconda3/envs/HiC/bin/correct-cnv", line 97, in run
    matrix_balance(args.hic, nproc=args.nproc)
  File "/mnt/work1/users/home2/hawleyj/miniconda3/envs/HiC/lib/python3.7/site-packages/neoloop/cnv/correctcnv.py", line 175, in matrix_balance
    clr = ice.Cooler(cool_uri)
AttributeError: module 'cooler.ice' has no attribute 'Cooler'
```

## Possible source of the problem

It looks like the error stems from [`correctcnv.py` line 175](https://github.com/XiaoTaoWang/NeoLoopFinder/blob/1f5ffb843212352a08ab76d7d90fdfec00912ad8/neoloop/cnv/correctcnv.py#L175):

```python3
    clr = ice.Cooler(cool_uri)
```

It looks like older versions of the cooler package had the `ice` module exporting `Cooler`, but it looks like some refactoring has taken place since.

## Possible fix

Instead, if you import `Cooler` directly, this appears to avoid the error.

```python3
from cooler import ice, util, Cooler
...
    clr = Cooler(cool_uri)
```

Making this change in `correctcnv.py` allows the above command to complete without error.
That's the change I've made in the first commit in this pull request.

The second commit switches the imported modules from the Cooler package from `ice` to `balance`, since `ice` was renamed as `balance` and deprecated back in [v0.8.0](https://github.com/open2c/cooler/blob/3d284485df070255f4a904102178b186c14c1cee/CHANGES.md#v080).

I haven't tested that all of these changes work perfectly, so it might be worth running some test data through the pipeline to make sure it works correctly.

Thanks,
James